### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ WARNING: Only `Load` can be used in this way.  If you return exported functions 
 
 Errors are caught and returned as text within the output cells.  The stacktrace is split down the column so select multiple cells for output as mentioned above.
 
-##Auxilliary Methods
+##Auxiliary Methods
 
 Excel REPL adds useful functions and macros to clojure.core that are useful when interacting with a worksheet.  Please see [excel-repl.clj](https://github.com/whamtet/Excel-REPL/blob/master/Excel-REPL/excel-repl.clj) for details.
 


### PR DESCRIPTION
whamtet, I've corrected a typographical error in the documentation of the [Excel-REPL](https://github.com/whamtet/Excel-REPL) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
